### PR TITLE
cookbook :deleted check for metadata.json

### DIFF
--- a/lib/chef_diff/changes/cookbook.rb
+++ b/lib/chef_diff/changes/cookbook.rb
@@ -62,7 +62,7 @@ module ChefDiff
         #   and will be re-uploaded
         if files
           .select { |x| x[:status] == :deleted }
-          .map { |x| x[:path].match(%{.*metadata\.rb$}) }
+          .map { |x| x[:path].match(%{.*metadata\.(rb|json)$}) }
           .compact
           .any?
           @status = :deleted


### PR DESCRIPTION
Some cookbooks do not have a metadata.rb, such as berks vendor'ed cookbooks. Allow checking for deleted cookbooks based on metadata.rb -or- metadata.json file.